### PR TITLE
Add /nic/update route

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ The hosted version is provided with absolutely no SLA whatsoever. I will update 
 
 The `/update` route is used for performing Dynamic DNS updates.
 
+The `/nic/update` route performs the same function, but is used for the "dyndns2" protocol in many clients.
+
 ### Configuration
 
 First, authentication information for CloudFlare needs to be provided. This can either be done via HTTP basic auth or via GET parameters.

--- a/main.go
+++ b/main.go
@@ -68,6 +68,7 @@ func init() {
 func main() {
 	// Handle the update route
 	http.HandleFunc("/update", updateHandler)
+	http.HandleFunc("/nic/update", updateHandler)
 
 	// Handle the checkip route
 	http.HandleFunc("/checkip", checkIPHandler)
@@ -96,6 +97,7 @@ func indexHandler(w http.ResponseWriter, r *http.Request) {
 			<h1>ClouDyn</h1>
 			<h2>Available Routes</h2>
 			<p><a href="update">/update</a> - Perform a DNS update</p>
+			<p><a href="nic/update">/nic/update</a> - Perform a DNS update (dyndns2)</p>
 			<p><a href="checkip">/checkip</a> - Get the current host's public IP</p>
 			<h2>Documentation</h2>
 			<p><a href="https://github.com/adammillerio/cloudyn">GitHub</a></p>


### PR DESCRIPTION
This PR adds the /nic/update route, which is identical to /update, but is used by the dyndns2 protocol format in many clients.